### PR TITLE
Add 'url' to the basics section

### DIFF
--- a/partials/basics.hbs
+++ b/partials/basics.hbs
@@ -16,11 +16,14 @@
 		<span class='divider'>|</span>
 		<span class='phone'>{{phone}}</span>
 		{{/if}}
-		{{#location}}
+		{{#if url}}
 		<span class='divider'>|</span>
-		<span class='address'>
+		<span class='url'>{{url}}</span>
+		{{/if}}
+		{{#location}}
+		<div class='address'>
 			{{#if city}}{{city}}{{/if}}{{#if region}}, {{region}}{{/if}}{{#if countryCode}}, {{countryCode}}{{/if}}
-		</span>
+		</div>
 		{{/location}}
 	</div>
 	{{#if profiles.length}}


### PR DESCRIPTION
The 'url' section of the Json file is missing on this theme.
This PR adds it back into the "basics" section on the header.